### PR TITLE
fix(deps): bump cryptography from 2.1.4 to 49.0.0

### DIFF
--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -92,7 +92,7 @@ azure-storage-nspkg<4.0.0,>=3.0.0
 azure-storage-blob~=1.3
 azure-storage-file~=1.3
 azure-storage-queue~=1.3
-cryptography>=2.1.4
+cryptography>=49.0.0
 futures
 mock
 typing


### PR DESCRIPTION
Bumps `cryptography` (pypi) from `2.1.4` to `49.0.0` in `shared_requirements.txt`.

### Why
| Signal | Value |
| --- | --- |
| Vulnerability | [CVE-2018-10903](https://nvd.nist.gov/vuln/detail/CVE-2018-10903) |
| Severity | high |
| CVSS | 7.5 |
| EPSS | not available for this finding |
| CISA KEV | not available for this finding |
| Reachability | unknown (no call-graph signal) |
| Fix status | fix available (scanner patched_versions) |

### Evidence
- OSBO finding: https://osbo.ai/drift?finding=aikido%3A97076696
- Target version source: deps.dev latest known release

---
_Opened by OSBO AutoFix. Review the diff before merging — the version bump is mechanical; compatibility is not verified._