### PR TITLE
fix(deps): bump uamqp from 1.2.0 to 1.6.7

### DIFF
--- a/shared_requirements.txt
+++ b/shared_requirements.txt
@@ -102,7 +102,7 @@ msrest>=0.5.0
 msrestazure<2.0.0,>=0.4.32
 azure-mgmt-core<2.0.0,>=1.0.0
 requests>=2.18.4
-uamqp~=1.2.0
+uamqp==1.6.7
 enum34>=1.0.4
 certifi>=2017.4.17
 aiohttp>=3.0


### PR DESCRIPTION
Bumps `uamqp` (pypi) from `1.2.0` to `1.6.7` in `shared_requirements.txt`.

### Why
| Signal | Value |
| --- | --- |
| Vulnerability | [AIKIDO-2024-10074](https://nvd.nist.gov/vuln/detail/AIKIDO-2024-10074) |
| Severity | critical |
| CVSS | 9.5 |
| EPSS | not available for this finding |
| CISA KEV | not available for this finding |
| Reachability | unknown (no call-graph signal) |
| Fix status | fix available (scanner patched_versions) |

### Evidence
- OSBO finding: https://osbo.ai/drift?finding=aikido%3A97076668
- Target version source: deps.dev latest known release

---
_Opened by OSBO AutoFix. Review the diff before merging — the version bump is mechanical; compatibility is not verified._